### PR TITLE
14 left pad

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ export default class CursorLocation extends Plugin {
     this.showUpdates = mode == "source";
     if (!this.showUpdates) {
       this.cursorStatusBar.setText("");
+      this.cursorStatusBar.removeAttribute("style");
     }
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -62,27 +62,19 @@ class CursorData {
   public anchorString(
     value: string,
     skipTotal: boolean = false,
-    genMax: boolean = false,
-    genMin: boolean = false,
   ): string {
-    const ch = genMax ? this.docCharCount : (genMin ? 1 : this.anchorChar);
-    const ln = genMax ? this.docLineCount : (genMin ? 1 : this.anchorLine);
     return this.partialString(value, skipTotal)
-      .replace("ch", ch.toString())
-      .replace("ln", ln.toString());
+      .replace("ch", this.anchorChar.toString())
+      .replace("ln", this.anchorLine.toString());
   }
 
   public headString(
     value: string,
     skipTotal: boolean = false,
-    genMax: boolean = false,
-    genMin: boolean = false,
   ): string {
-    const ch = genMax ? this.docCharCount : this.headChar;
-    const ln = genMax ? this.docLineCount : this.headLine;
     return this.partialString(value, skipTotal)
-      .replace("ch", ch.toString())
-      .replace("ln", ln.toString());
+      .replace("ch", this.headChar.toString())
+      .replace("ln", this.headLine.toString());
   }
 }
 
@@ -90,33 +82,35 @@ class EditorPlugin implements PluginValue {
   private hasPlugin: boolean;
   private view: EditorView;
   private plugin: CursorLocation;
-  private canvas: HTMLElement;
+  private canvasContext: any; // idk what type this should actually be
 
   constructor(view: EditorView) {
     this.view = view;
     this.hasPlugin = false;
   }
 
-  private calculateWidth(display: string): any {
+  private calculateWidth(display: string, updateFont: boolean = true): number {
     const statusBar = this.plugin.cursorStatusBar;
-    if (!this.canvas) {
-      this.canvas = statusBar.createEl("canvas");
+    if (!this.canvasContext) {
+      const canvas: HTMLElement = statusBar.createEl("canvas");
+    // @ts-ignore
+      this.canvasContext = canvas.getContext("2d");
     }
 
-    const fontWeight = statusBar.getCssPropertyValue("font-weight") || "normal";
-    const fontSize = statusBar.getCssPropertyValue("font-size") || "12pt";
-    const fontFamily = statusBar.getCssPropertyValue("font-family") || "ui-sans-serif";
-    const font = `${fontWeight} ${fontSize} ${fontFamily}`;
+    if (updateFont) {
+      const fontWeight = statusBar.getCssPropertyValue("font-weight") || "normal";
+      const fontSize = statusBar.getCssPropertyValue("font-size") || "12pt";
+      const fontFamily = statusBar.getCssPropertyValue("font-family") || "ui-sans-serif";
+      const font = `${fontWeight} ${fontSize} ${fontFamily}`;
+      this.canvasContext.font = font;
+    }
 
+    const metrics = this.canvasContext.measureText(display);
     const pad = parseInt(statusBar.getCssPropertyValue("padding-right").replace("px", ""));
 
-    // @ts-ignore
-    const context = this.canvas.getContext("2d");
-    context.font = font;
-
-    const metrics = context.measureText(display);
-    console.log(metrics.width, display);
-    return metrics.width + pad + pad;;
+    const width = Math.floor(metrics.width + pad + pad);
+    console.log(width, metrics.width, display);
+    return width;
   }
 
   update(): void {
@@ -139,45 +133,33 @@ class EditorPlugin implements PluginValue {
     const settings = this.plugin.settings;
     if (selections && settings.numberCursors) {
       let display: string;
-      // let maxDisplay: string;
-      // let minDisplay: string;
       if (selections.length == 1) {
         display = this.cursorDisplay(selections[0]);
-        // maxDisplay = this.cursorDisplay(selections[0], false, false, true);
-        // minDisplay = this.cursorDisplay(selections[0], false, false, false, true);
       } else if (selections.length <= settings.numberCursors) {
         let cursorStrings: string[] = [];
-        // let maxCursorStrings: string[] = [];
-        // let minCursorStrings: string[] = [];
         selections.forEach((value) => {
           cursorStrings.push(this.cursorDisplay(value, true, true));
-          // maxCursorStrings.push(this.cursorDisplay(value, true, true, true));
-          // minCursorStrings.push(this.cursorDisplay(value, true, true, false, true));
         });
         display = cursorStrings.join(settings.cursorSeperator);
-        // maxDisplay = maxCursorStrings.join(settings.cursorSeperator);
-        // minDisplay = minCursorStrings.join(settings.cursorSeperator);
         if (/ct/.test(settings.displayPattern)) {
           display += settings.cursorSeperator + docLines;
-          // maxDisplay += settings.cursorSeperator + docLines;
-          // minDisplay += settings.cursorSeperator + 1;
         }
       } else {
         display = format(MULTCURSORS, selections.length);
-        // maxDisplay = display;
-        // minDisplay = display;
       }
       if (totalSelect != 0) {
         display += this.totalDisplay(totalSelect, totalLine);
-        // maxDisplay += this.totalDisplay(docChars, docLines);
-        // minDisplay += this.totalDisplay(1, 1);
       }
 
-      // const maxWidth = this.calculateWidth(display);
-      // const minWidth = this.calculateWidth(minDisplay);
-      // const width = (maxWidth+minWidth)/2
-      // this.plugin.cursorStatusBar.setAttribute("style", `width:${maxWidth}px;`);
-      // this.plugin.cursorStatusBar.setAttribute("style", `width:${width}px;`);
+      if (settings.statusBarPadding) {
+        const ogWidth = this.calculateWidth(display);
+
+        let width: number = ogWidth;
+        let padWidth: number = Math.ceil(ogWidth/9.0)*9;
+        if (width == padWidth) padWidth += 3;
+        console.log(padWidth, width);
+        this.plugin.cursorStatusBar.setAttribute("style", `justify-content:right;width:${padWidth}px;`);
+      }
       this.plugin.cursorStatusBar.setText(display);
     }
   }
@@ -194,22 +176,20 @@ class EditorPlugin implements PluginValue {
     selection: CursorData,
     displayLines: boolean = false,
     skipTotal: boolean = false,
-    genMax: boolean = false,
-    genMin: boolean = false,
   ): string {
     let value: string;
     const settings = this.plugin.settings;
     if (settings.selectionMode == "begin") {
-      value = selection.anchorString(settings.displayPattern, skipTotal, genMax, genMin);
+      value = selection.anchorString(settings.displayPattern, skipTotal);
     } else if (settings.selectionMode == "end") {
-      value = selection.headString(settings.displayPattern, skipTotal, genMax, genMin);
+      value = selection.headString(settings.displayPattern, skipTotal);
     } else if (selection.highlightedChars == 0) {
-      value = selection.headString(settings.displayPattern, skipTotal, genMax, genMin);
+      value = selection.headString(settings.displayPattern, skipTotal);
     } else {
       value =
-        selection.anchorString(settings.displayPattern, true, genMax, genMin) +
+        selection.anchorString(settings.displayPattern, true) +
         settings.rangeSeperator +
-        selection.headString(settings.displayPattern, skipTotal, genMax, genMin);
+        selection.headString(settings.displayPattern, skipTotal);
     }
     if (displayLines && settings.displayCursorLines) {
       let numberLines = Math.abs(selection.anchorLine - selection.headLine) + 1;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -109,7 +109,6 @@ class EditorPlugin implements PluginValue {
     const pad = parseInt(statusBar.getCssPropertyValue("padding-right").replace("px", ""));
 
     const width = Math.floor(metrics.width + pad + pad);
-    console.log(width, metrics.width, display);
     return width;
   }
 
@@ -152,13 +151,16 @@ class EditorPlugin implements PluginValue {
       }
 
       if (settings.statusBarPadding) {
-        const ogWidth = this.calculateWidth(display);
-
-        let width: number = ogWidth;
-        let padWidth: number = Math.ceil(ogWidth/9.0)*9;
-        if (width == padWidth) padWidth += 3;
-        console.log(padWidth, width);
-        this.plugin.cursorStatusBar.setAttribute("style", `justify-content:right;width:${padWidth}px;`);
+        const step = settings.paddingStep;
+        const width = this.calculateWidth(display);
+        let padWidth: number = Math.ceil(width/step)*step;
+        if (width == padWidth) padWidth += Math.ceil(step/3);
+        this.plugin.cursorStatusBar.setAttribute(
+          "style",
+          `justify-content:right;width:${padWidth}px;`
+        );
+      } else {
+        this.plugin.cursorStatusBar.removeAttribute("style");
       }
       this.plugin.cursorStatusBar.setText(display);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export interface CursorLocationSettings {
   displayTotalLines: boolean;
   displayCursorLines: boolean;
   cursorLinePattern: string;
+  statusBarPadding: boolean;
 }
 
 export const DEFAULT_SETTINGS: CursorLocationSettings = {
@@ -24,6 +25,7 @@ export const DEFAULT_SETTINGS: CursorLocationSettings = {
   displayTotalLines: true,
   displayCursorLines: false,
   cursorLinePattern: "[lc]",
+  statusBarPadding: false,
 };
 
 export class CursorLocationSettingTab extends PluginSettingTab {
@@ -325,6 +327,36 @@ export class CursorLocationSettingTab extends PluginSettingTab {
         })
       );
 
+    let statusBarPaddingEl = containerEl.createDiv();
+    statusBarPaddingEl.createEl("h3", { text: "Pad Status Bar" });
+    let statusBarPadding = new Setting(statusBarPaddingEl)
+      .setName("Add padding to lessen the amount the status bar shifts")
+      .addToggle((cb) =>
+        cb
+          .setValue(
+            this.plugin.settings.statusBarPadding != null
+              ? this.plugin.settings.statusBarPadding
+              : DEFAULT_SETTINGS.statusBarPadding
+          )
+          .onChange(async (value) => {
+            if (this.plugin.settings.statusBarPadding != value) {
+              console.log(`changing statusBarPadding: ${value}`);
+            }
+            this.plugin.settings.statusBarPadding = value;
+            await this.plugin.saveSettings();
+          })
+      );
+    new Setting(statusBarPaddingEl)
+      .setName(
+        `Reset to default value of '${DEFAULT_SETTINGS.statusBarPadding}'`
+      )
+      .addButton((cb) =>
+        cb.setButtonText("Reset").onClick(async () => {
+          this.resetComponent(statusBarPadding, "statusBarPadding");
+          await this.plugin.saveSettings();
+        })
+      );
+
     containerEl.createDiv().createEl("h2", { text: "Reset All Settings" });
     const cursorLocationSettings = [
       { elem: numberCursors, setting: "numberCursors" },
@@ -336,6 +368,7 @@ export class CursorLocationSettingTab extends PluginSettingTab {
       { elem: rangeSeperator, setting: "rangeSeperator" },
       { elem: displayCursorLineCount, setting: "displayCursorLines" },
       { elem: cursorLinePattern, setting: "cursorLinePattern" },
+      // { elem: cursorLinePattern, setting: "cursorLinePattern" },
     ];
 
     let resetAllEl = containerEl.createDiv();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export interface CursorLocationSettings {
   displayCursorLines: boolean;
   cursorLinePattern: string;
   statusBarPadding: boolean;
+  paddingStep: number;
 }
 
 export const DEFAULT_SETTINGS: CursorLocationSettings = {
@@ -26,6 +27,7 @@ export const DEFAULT_SETTINGS: CursorLocationSettings = {
   displayCursorLines: false,
   cursorLinePattern: "[lc]",
   statusBarPadding: false,
+  paddingStep: 9,
 };
 
 export class CursorLocationSettingTab extends PluginSettingTab {
@@ -40,7 +42,7 @@ export class CursorLocationSettingTab extends PluginSettingTab {
     const value = DEFAULT_SETTINGS[setting];
     console.log(`resetting ${setting}: ${value}`);
     let component = elem.components[0] as ValueComponent<any>;
-    component.setValue(value);
+    component.setValue(value?.toString());
     this.plugin.settings[setting] = value;
   }
 
@@ -64,7 +66,7 @@ export class CursorLocationSettingTab extends PluginSettingTab {
             let parsedValue = parseInt(value);
             if (!isNaN(parsedValue)) {
               console.log(`updating numberCursors: ${parsedValue}`);
-              warningSection.setText("");
+              cursorWarningSection.setText("");
               this.plugin.settings.numberCursors = parsedValue;
               await this.plugin.saveSettings();
             } else {
@@ -72,13 +74,13 @@ export class CursorLocationSettingTab extends PluginSettingTab {
                 "unable to update numberCursors, ",
                 `unable to parse new value into integer: ${value}`
               );
-              warningSection.setText(
+              cursorWarningSection.setText(
                 `"${value}" is not a number, unable to save.`
               );
             }
           })
       );
-    let warningSection = cursorEl.createEl("p", {
+    let cursorWarningSection = cursorEl.createEl("p", {
       text: "",
       attr: { style: "color:red" },
     });
@@ -87,7 +89,7 @@ export class CursorLocationSettingTab extends PluginSettingTab {
       .addButton((cb) =>
         cb.setButtonText("Reset").onClick(async () => {
           this.resetComponent(numberCursors, "numberCursors");
-          warningSection.setText("");
+          cursorWarningSection.setText("");
           await this.plugin.saveSettings();
         })
       );
@@ -357,6 +359,47 @@ export class CursorLocationSettingTab extends PluginSettingTab {
         })
       );
 
+    let paddingStepEl = containerEl.createDiv();
+    paddingStepEl.createEl("h3", { text: "# of Cursors" });
+    let paddingStep = new Setting(paddingStepEl)
+      .setName(
+        'Width the status bar rounds to to prevent rapid changing.'
+      )
+      .addText((text) =>
+        text
+          .setValue(this.plugin.settings?.paddingStep?.toString())
+          .onChange(async (value) => {
+            let parsedValue = parseInt(value);
+            if (!isNaN(parsedValue)) {
+              console.log(`updating paddingStep: ${parsedValue}`);
+              paddingStepWarningSection.setText("");
+              this.plugin.settings.paddingStep = parsedValue;
+              await this.plugin.saveSettings();
+            } else {
+              console.log(
+                "unable to update paddingStep, ",
+                `unable to parse new value into integer: ${value}`
+              );
+              paddingStepWarningSection.setText(
+                `"${value}" is not a number, unable to save.`
+              );
+            }
+          })
+      );
+    let paddingStepWarningSection = paddingStepEl.createEl("p", {
+      text: "",
+      attr: { style: "color:red" },
+    });
+    new Setting(paddingStepEl)
+      .setName(`Reset to default value of '${DEFAULT_SETTINGS.paddingStep}'`)
+      .addButton((cb) =>
+        cb.setButtonText("Reset").onClick(async () => {
+          this.resetComponent(paddingStep, "paddingStep");
+          paddingStepWarningSection.setText("");
+          await this.plugin.saveSettings();
+        })
+      );
+
     containerEl.createDiv().createEl("h2", { text: "Reset All Settings" });
     const cursorLocationSettings = [
       { elem: numberCursors, setting: "numberCursors" },
@@ -368,7 +411,8 @@ export class CursorLocationSettingTab extends PluginSettingTab {
       { elem: rangeSeperator, setting: "rangeSeperator" },
       { elem: displayCursorLineCount, setting: "displayCursorLines" },
       { elem: cursorLinePattern, setting: "cursorLinePattern" },
-      // { elem: cursorLinePattern, setting: "cursorLinePattern" },
+      { elem: statusBarPadding, setting: "statusBarPadding" },
+      { elem: paddingStep, setting: "paddingStep" },
     ];
 
     let resetAllEl = containerEl.createDiv();
@@ -380,7 +424,7 @@ export class CursorLocationSettingTab extends PluginSettingTab {
           cursorLocationSettings.forEach((setting) => {
             this.resetComponent(setting.elem, setting.setting);
           });
-          warningSection.setText("");
+          cursorWarningSection.setText("");
           await this.plugin.saveSettings();
         })
       );


### PR DESCRIPTION
Pad the status bar to try and keep it from flickering when moving between some columns like 9 and 10 or 99 and 100 or lines 99 to 100. Things like that. Toggle-able setting that is `false` by default to keep same behavior as before.

Resolves #14 